### PR TITLE
Let Users Define the Session Cookie Name

### DIFF
--- a/class-wp-session.php
+++ b/class-wp-session.php
@@ -69,8 +69,8 @@ class WP_Session implements ArrayAccess {
 	 * @uses apply_filters Calls `wp_session_expiration` to determine how long until sessions expire.
 	 */
 	private function __construct() {
-		if ( isset( $_COOKIE['_wp_session'] ) ) {
-			$this->session_id = stripslashes( $_COOKIE['_wp_session'] );
+		if ( isset( $_COOKIE[WP_SESSION_COOKIE] ) ) {
+			$this->session_id = stripslashes( $_COOKIE[WP_SESSION_COOKIE] );
 		} else {
 			$this->session_id = $this->generate_id();
 		}
@@ -79,7 +79,7 @@ class WP_Session implements ArrayAccess {
 
 		$this->cache_expire = intval( apply_filters( 'wp_session_expiration', 24 * 60 ) );
 
-		setcookie( '_wp_session', $this->session_id, time() + $this->cache_expire, COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( WP_SESSION_COOKIE, $this->session_id, time() + $this->cache_expire, COOKIEPATH, COOKIE_DOMAIN );
 	}
 
 	/**
@@ -161,7 +161,7 @@ class WP_Session implements ArrayAccess {
 
 		$this->session_id = $this->generate_id();
 
-		setcookie( '_wp_session', $this->session_id, time() + $this->cache_expire, COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( WP_SESSION_COOKIE, $this->session_id, time() + $this->cache_expire, COOKIEPATH, COOKIE_DOMAIN );
 	}
 
 	/**

--- a/wp-session-manager.php
+++ b/wp-session-manager.php
@@ -9,6 +9,10 @@
  * License: GPLv2+
  */
 
+// let users change the session cookie name
+if( ! defined( 'WP_SESSION_COOKIE' ) )
+	define( 'WP_SESSION_COOKIE', '_wp_session' );
+
 // Only include the functionality if it's not pre-defined.
 if ( ! class_exists( 'WP_Session' ) ) {
 	require_once( 'class-wp-session.php' );


### PR DESCRIPTION
Allow users to put a cookie name in their `wp-config.php` file in the
same way that the WP core does.  This introduces a new constant
`WP_SESSION_COOKIE`.
