### PR TITLE
Removed unnecessary closing php tags.

### DIFF
--- a/class-recursive-arrayaccess.php
+++ b/class-recursive-arrayaccess.php
@@ -132,8 +132,7 @@ class Recursive_ArrayAccess implements ArrayAccess {
 	 */
 	public function offsetUnset( $offset ) {
 		unset( $this->container[ $offset ] );
-		
+
 		$this->dirty = true;
 	}
 }
-?>

--- a/wp-session-manager.php
+++ b/wp-session-manager.php
@@ -22,4 +22,3 @@ if ( ! class_exists( 'WP_Session' ) ) {
 	require_once( 'class-wp-session.php' );
 	require_once( 'wp-session.php' );
 }
-?>

--- a/wp-session.php
+++ b/wp-session.php
@@ -167,4 +167,3 @@ function wp_session_register_garbage_collection() {
 	}
 }
 add_action( 'wp', 'wp_session_register_garbage_collection' );
-?>


### PR DESCRIPTION
It's generally recommended to leave out closing php tags to prevent excess whitespace creeping in and creating issues with headers being sent prior to php trying to set them.
