### PR TITLE
Added addslashes to prevent SQL error

### DIFF
--- a/wp-session.php
+++ b/wp-session.php
@@ -139,7 +139,7 @@ function wp_session_cleanup() {
 			// If the session has expired
 			if ( $now > intval( $expiration->option_value ) ) {
 				// Get the session ID by parsing the option_name
-				$session_id = substr( $expiration->option_name, 20 );
+				$session_id = addslashes(substr( $expiration->option_name, 20 ));
 
 				$expired_sessions[] = $expiration->option_name;
 				$expired_sessions[] = "_wp_session_$session_id";


### PR DESCRIPTION
After deploying this plugin to a fairly high traffic site, we saw well over 25k SQL errors regarding a '_wp_session_-1'' being in the query to clear out expired sessions. I added the addslashes line to prevent this. However, I have yet to locate the root cause of this issue and how a session id of 1' is being generated. 
