### PR TITLE
Make session ID publicly accessible

### DIFF
--- a/includes/class-wp-session.php
+++ b/includes/class-wp-session.php
@@ -22,7 +22,7 @@ final class WP_Session extends Recursive_ArrayAccess {
 	 *
 	 * @var string
 	 */
-	protected $session_id;
+	public $session_id;
 
 	/**
 	 * Unix timestamp when session expires.


### PR DESCRIPTION
It can be useful to be able to grab the session ID in some scenarios.