### PR TITLE
Change prefix for better integration with proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Description
 Adds `$_SESSION`-like functionality to WordPress.
 
 Every visitor, logged in or not, will be issued an instance of `WP_Session`.  Their instance will be identified by an ID
-stored in the `_wp_session` cookie.  Typically, session data will be stored in a WordPress transient, but if your
+stored in the `wordpress_session` cookie.  Typically, session data will be stored in a WordPress transient, but if your
 installation has a caching system in-place (i.e. memcached), the session data might be stored in memory.
 
 This provides plugin and theme authors the ability to use WordPress-managed session variables without having to use the

--- a/includes/class-wp-session-utils.php
+++ b/includes/class-wp-session-utils.php
@@ -16,7 +16,7 @@ class WP_Session_Utils {
 	public static function count_sessions() {
 		global $wpdb;
 
-		$query = "SELECT COUNT(*) FROM $wpdb->options WHERE option_name LIKE '_wp_session_expires_%'";
+		$query = "SELECT COUNT(*) FROM $wpdb->options WHERE option_name LIKE 'wordpress_session_expires_%'";
 
 		/**
 		 * Filter the query in case tables are non-standard.
@@ -60,8 +60,8 @@ class WP_Session_Utils {
 		$session_id = self::generate_id();
 
 		// Store the session
-		add_option( "_wp_session_{$session_id}", array(), '', 'no' );
-		add_option( "_wp_session_expires_{$session_id}", $expires, '', 'no' );
+		add_option( "wordpress_session_{$session_id}", array(), '', 'no' );
+		add_option( "wordpress_session_expires_{$session_id}", $expires, '', 'no' );
 	}
 
 	/**
@@ -77,7 +77,7 @@ class WP_Session_Utils {
 		global $wpdb;
 
 		$limit = absint( $limit );
-		$keys = $wpdb->get_results( "SELECT option_name, option_value FROM $wpdb->options WHERE option_name LIKE '_wp_session_expires_%' ORDER BY option_value ASC LIMIT 0, {$limit}" );
+		$keys = $wpdb->get_results( "SELECT option_name, option_value FROM $wpdb->options WHERE option_name LIKE 'wordpress_session_expires_%' ORDER BY option_value ASC LIMIT 0, {$limit}" );
 
 		$now = time();
 		$expired = array();
@@ -91,7 +91,7 @@ class WP_Session_Utils {
 				$session_id = preg_replace("/[^A-Za-z0-9_]/", '', substr( $key, 20 ) );
 
 				$expired[] = $key;
-				$expired[] = "_wp_session_{$session_id}";
+				$expired[] = "wordpress_session_{$session_id}";
 
 				$count += 1;
 			}
@@ -120,7 +120,7 @@ class WP_Session_Utils {
 	public static function delete_all_sessions() {
 		global $wpdb;
 
-		$count = $wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE '_wp_session_%'" );
+		$count = $wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'wordpress_session_%'" );
 
 		return (int) ( $count / 2 );
 	}

--- a/includes/class-wp-session.php
+++ b/includes/class-wp-session.php
@@ -80,8 +80,8 @@ final class WP_Session extends Recursive_ArrayAccess {
 			// Update the session expiration if we're past the variant time
 			if ( time() > $this->exp_variant ) {
 				$this->set_expiration();
-				delete_option( "_wp_session_expires_{$this->session_id}" );
-				add_option( "_wp_session_expires_{$this->session_id}", $this->expires, '', 'no' );
+				delete_option( "wordpress_session_expires_{$this->session_id}" );
+				add_option( "wordpress_session_expires_{$this->session_id}", $this->expires, '', 'no' );
 			}
 		} else {
 			$this->session_id = WP_Session_Utils::generate_id();
@@ -136,7 +136,7 @@ final class WP_Session extends Recursive_ArrayAccess {
 	 * @return array
 	 */
 	protected function read_data() {
-		$this->container = get_option( "_wp_session_{$this->session_id}", array() );
+		$this->container = get_option( "wordpress_session_{$this->session_id}", array() );
 
 		return $this->container;
 	}
@@ -145,14 +145,14 @@ final class WP_Session extends Recursive_ArrayAccess {
 	 * Write the data from the current session to the data storage system.
 	 */
 	public function write_data() {
-		$option_key = "_wp_session_{$this->session_id}";
+		$option_key = "wordpress_session_{$this->session_id}";
 		
 		if ( false === get_option( $option_key ) ) {
-			add_option( "_wp_session_{$this->session_id}", $this->container, '', 'no' );
-			add_option( "_wp_session_expires_{$this->session_id}", $this->expires, '', 'no' );
+			add_option( "wordpress_session_{$this->session_id}", $this->container, '', 'no' );
+			add_option( "wordpress_session_expires_{$this->session_id}", $this->expires, '', 'no' );
 		} else {
-			delete_option( "_wp_session_{$this->session_id}" );
-			add_option( "_wp_session_{$this->session_id}", $this->container, '', 'no' );
+			delete_option( "wordpress_session_{$this->session_id}" );
+			add_option( "wordpress_session_{$this->session_id}", $this->container, '', 'no' );
 		}
 	}
 
@@ -190,7 +190,7 @@ final class WP_Session extends Recursive_ArrayAccess {
 	 */
 	public function regenerate_id( $delete_old = false ) {
 		if ( $delete_old ) {
-			delete_option( "_wp_session_{$this->session_id}" );
+			delete_option( "wordpress_session_{$this->session_id}" );
 		}
 
 		$this->session_id = WP_Session_Utils::generate_id();

--- a/includes/wp-session.php
+++ b/includes/wp-session.php
@@ -68,7 +68,7 @@ function wp_session_regenerate_id( $delete_old_session = false ) {
 /**
  * Start new or resume existing session.
  *
- * Resumes an existing session based on a value sent by the _wp_session cookie.
+ * Resumes an existing session based on a value sent by the wordpress_session cookie.
  *
  * @return bool
  */

--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ Prototype session management for WordPress.
 Adds `$_SESSION`-like functionality to WordPress.
 
 Every visitor, logged in or not, will be issued an instance of `WP_Session`.  Their instance will be identified by an ID
-stored in the `_wp_session` cookie.  Typically, session data will be stored in a WordPress transient, but if your
+stored in the `wordpress_session` cookie.  Typically, session data will be stored in a WordPress transient, but if your
 installation has a caching system in-place (i.e. memcached), the session data might be stored in memory.
 
 This provides plugin and theme authors the ability to use WordPress-managed session variables without having to use the

--- a/wp-session-manager.php
+++ b/wp-session-manager.php
@@ -11,7 +11,7 @@
 
 // let users change the session cookie name
 if( ! defined( 'WP_SESSION_COOKIE' ) ) {
-	define( 'WP_SESSION_COOKIE', '_wp_session' );
+	define( 'WP_SESSION_COOKIE', 'wordpress_session' );
 }
 
 if ( ! class_exists( 'Recursive_ArrayAccess' ) ) {


### PR DESCRIPTION
The `wordpress_` prefix for is commonly being used for wordpress internal
cookies. Some wordpress hosting sites, for example wpengine, are using
those cookies to decide if a page will be served from cache or from the
application server directly. I propose to rename the the wp_session
cookie to conform this prefix as a saner default.