### PR TITLE
Avoid storing empty session in options table

### DIFF
--- a/includes/class-wp-session.php
+++ b/includes/class-wp-session.php
@@ -81,6 +81,7 @@ final class WP_Session extends Recursive_ArrayAccess {
 			if ( time() > $this->exp_variant ) {
 				$this->set_expiration();
 				delete_option( "_wp_session_expires_{$this->session_id}" );
+				add_option( "_wp_session_expires_{$this->session_id}", $this->expires, '', 'no' );
 			}
 		} else {
 			$this->session_id = WP_Session_Utils::generate_id();

--- a/includes/class-wp-session.php
+++ b/includes/class-wp-session.php
@@ -81,7 +81,6 @@ final class WP_Session extends Recursive_ArrayAccess {
 			if ( time() > $this->exp_variant ) {
 				$this->set_expiration();
 				delete_option( "_wp_session_expires_{$this->session_id}" );
-				add_option( "_wp_session_expires_{$this->session_id}", $this->expires, '', 'no' );
 			}
 		} else {
 			$this->session_id = WP_Session_Utils::generate_id();
@@ -145,6 +144,12 @@ final class WP_Session extends Recursive_ArrayAccess {
 	 * Write the data from the current session to the data storage system.
 	 */
 	public function write_data() {
+
+		// No need to store an empty array in the DB
+		if( $this->container === array() ){
+			return;
+		}
+		
 		$option_key = "_wp_session_{$this->session_id}";
 		
 		if ( false === get_option( $option_key ) ) {


### PR DESCRIPTION
We have a website that is storing 250k-500k options as a result of this library being included -- even with frequent garbage collection -- as a new session is created for every visitor regardless of whether it is needed to store anything. As WordPress has a "default" argument for get_option, there's no reason to clutter up the options table with empty strings or empty arrays.