### PR TITLE
Fix breaking change in WP_Session API

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -159,13 +159,33 @@ function wp_session_register_garbage_collection()
     _doing_it_wrong('wp_session_register_garbage_collection', 'Sessions are cleaned up natively.', '3.0');
 }
 
-if ( ! class_exists('WP_Session') ) :
-class WP_Session {
+if ( ! class_exists('WP_Session') ) : 
+class WP_Session implements ArrayAccess {
     public static function get_instance()
-    {
+    {   
         _doing_it_wrong('WP_Session::get_instance', 'Please use native Session functionality.', '3.0');
 
-        return $_SESSION;
-    }
+        return new WP_Session();
+    }   
+
+    public function offsetExists($offset)
+    {   
+        return isset($_SESSION[$offset]);
+    }   
+
+    public function offsetGet($offset)
+    {   
+        return $_SESSION[$offset];
+    }   
+
+    public function offsetSet($offset, $value)
+    {   
+        $_SESSION[$offset] = $value;
+    }   
+
+    public function offsetUnset($offset)
+    {   
+        unset($_SESSION[$offset]);
+    }   
 }
 endif;


### PR DESCRIPTION
Implement ArrayAccess interface and return an instance of WP_Session from WP_Session::get_instance().  This still uses the native $_SESSION superglobal to read and write session data but doesn't break any plugins that used WP_Session type hints or instanceof checks.