### PR TITLE
4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Changelog
 **4.1.0**
 - Fix: Add some defense to ensure end users are running the correct version of PHP before loading the system.
 - Fix: Eliminate a race condition where another plugin or the theme created the session first.
+- Fix: Schedule a cron to auto-delete expired sessions.
 
 **4.0.0**
 - New: Add an object cache based handler to leverage Redis or Memcached if available for faster queries.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Absolutely! As of version 2.0, this plugin will create a new table for WordPress
 define( 'WP_SESSION_USE_OPTIONS', true );
 ```
 
+**I get an error saying my PHP version is out of date. Why?**
+
+PHP 5.6 was designated end-of-life and stopped receiving security patches in December 2018. PHP 7.0 was _also_ marked end-of-life in December 2018. The minimum version of PHP supported by WP Session Manager is now PHP 7.1.
+
+If your server is running an older version of PHP, the session system _will not work!_ To avoid triggering a PHP error, the plugin will instead output this notice to upgrade and disable itself silently. You won't see a PHP error, but you also won't get session support.
+
+Reach out to your hosting provider or system administrator to upgrade your server.
+
+**I get an error saying another plugin is setting up a session. What can I do?**
+
+WP Session Manager overrides PHP's default session implementation with its own custom handler. Unfortunately, we can't swap in a new handler if a session is already active. This plugin hooks into the `plugins_loaded` hook to set things up as early as possible, but if you have code in _another_ plugin (or your theme) that attempts to invoke `session_start()` before WP Session Manager loads, then the custom handler won't work at all.
+
+Inspect your other plugins and try to find the one that's interfering. Then, reach out to the developer to explain the conflict and see if they have a fix.
+
 Screenshots
 -----------
 
@@ -58,6 +72,7 @@ Changelog
 
 **4.1.0**
 - Fix: Add some defense to ensure end users are running the correct version of PHP before loading the system.
+- Fix: Eliminate a race condition where another plugin or the theme created the session first.
 
 **4.0.0**
 - New: Add an object cache based handler to leverage Redis or Memcached if available for faster queries.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ None
 Changelog
 ---------
 
+**4.1.0**
+- Fix: Add some defense to ensure end users are running the correct version of PHP before loading the system.
+
 **4.0.0**
 - New: Add an object cache based handler to leverage Redis or Memcached if available for faster queries.
 - New: Adopt the Contributor Covenant (v1.4) as the project's official code of conduct.
@@ -161,7 +164,7 @@ Additional Information
 **Requires at least:** 4.7  
 **Tested up to:** 5.0.2  
 **Requires PHP:** 7.1  
-**Stable tag:** 4.0.0  
+**Stable tag:** 4.1.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name"             : "ericmann/wp-session-manager",
 	"description"      : "Prototype session management for WordPress.",
-	"version"          : "4.0.0",
+	"version"          : "4.1.0",
 	"type"             : "wordpress-plugin",
 	"keywords"         : ["session"],
 	"homepage"         : "https://github.com/ericmann/wp-session-manager",

--- a/includes/DatabaseHandler.php
+++ b/includes/DatabaseHandler.php
@@ -252,11 +252,21 @@ class DatabaseHandler extends SessionHandler
      * @param int $maxlifetime (Unused).
      * @param callable $next Next clean operation in the stack.
      *
-     * @global \wpdb $wpdb
-     *
      * @return mixed
      */
     public function clean($maxlifetime, $next)
+    {
+        self::directClean();
+
+        return $next($maxlifetime);
+    }
+
+    /**
+     * Update the database by removing any sessions that are no longer valid
+     *
+     * @global \wpdb $wpdb
+     */
+    public static function directClean()
     {
         global $wpdb;
 
@@ -269,7 +279,5 @@ class DatabaseHandler extends SessionHandler
                 )
             );
         }
-
-        return $next($maxlifetime);
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,7 @@ None
 = 4.1.0 =
 * Fix: Add some defense to ensure end users are running the correct version of PHP before loading the system.
 * Fix: Eliminate a race condition where another plugin or the theme created the session first.
+* Fix: Schedule a cron to auto-delete expired sessions.
 
 = 4.0.0 =
 * New: Add an object cache based handler to leverage Redis or Memcached if available for faster queries.

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,20 @@ Absolutely! As of version 2.0, this plugin will create a new table for WordPress
 define( 'WP_SESSION_USE_OPTIONS', true );
 `
 
+= I get an error saying my PHP version is out of date. Why? =
+
+PHP 5.6 was designated end-of-life and stopped receiving security patches in December 2018. PHP 7.0 was _also_ marked end-of-life in December 2018. The minimum version of PHP supported by WP Session Manager is now PHP 7.1.
+
+If your server is running an older version of PHP, the session system _will not work!_ To avoid triggering a PHP error, the plugin will instead output this notice to upgrade and disable itself silently. You won't see a PHP error, but you also won't get session support.
+
+Reach out to your hosting provider or system administrator to upgrade your server.
+
+= I get an error saying another plugin is setting up a session. What can I do? =
+
+WP Session Manager overrides PHP's default session implementation with its own custom handler. Unfortunately, we can't swap in a new handler if a session is already active. This plugin hooks into the `plugins_loaded` hook to set things up as early as possible, but if you have code in _another_ plugin (or your theme) that attempts to invoke `session_start()` before WP Session Manager loads, then the custom handler won't work at all.
+
+Inspect your other plugins and try to find the one that's interfering. Then, reach out to the developer to explain the conflict and see if they have a fix.
+
 == Screenshots ==
 
 None
@@ -62,6 +76,7 @@ None
 
 = 4.1.0 =
 * Fix: Add some defense to ensure end users are running the correct version of PHP before loading the system.
+* Fix: Eliminate a race condition where another plugin or the theme created the session first.
 
 = 4.0.0 =
 * New: Add an object cache based handler to leverage Redis or Memcached if available for faster queries.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags:              session
 Requires at least: 4.7
 Tested up to:      5.0.2
 Requires PHP:      7.1
-Stable tag:        4.0.0
+Stable tag:        4.1.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,6 +59,9 @@ define( 'WP_SESSION_USE_OPTIONS', true );
 None
 
 == Changelog ==
+
+= 4.1.0 =
+* Fix: Add some defense to ensure end users are running the correct version of PHP before loading the system.
 
 = 4.0.0 =
 * New: Add an object cache based handler to leverage Redis or Memcached if available for faster queries.

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EAMann\WPSession;
+
+use PHPUnit\Framework\TestCase;
+
+class DatabaseHandlerTest extends TestCase
+{
+
+    public function test_create()
+    {
+        $handler = new DatabaseHandler();
+
+        $called = false;
+        $callback = function($path, $name) use (&$called) {
+            $this->assertEquals('path', $path);
+            $this->assertEquals('name', $name);
+
+            $called = true;
+        };
+
+        $handler->create('path', 'name', $callback);
+
+        $this->assertTrue($called);
+    }
+
+}

--- a/wp-session-manager.php
+++ b/wp-session-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Session Manager
  * Plugin URI:  https://paypal.me/eam
  * Description: Session management for WordPress.
- * Version:     4.0.0
+ * Version:     4.1.0
  * Author:      Eric Mann
  * Author URI:  https://eamann.com
  * License:     GPLv2+
@@ -11,43 +11,72 @@
  * @package WP Session Manager
  */
 
-$wp_session_autoload = __DIR__ . '/vendor/autoload.php';
-if (file_exists($wp_session_autoload)) {
-    require_once $wp_session_autoload;
+if(!defined('WP_SESSION_MINIMUM_PHP_VERSION')) {
+    define('WP_SESSION_MINIMUM_PHP_VERSION', '7.1.0');
 }
 
-if (!class_exists('EAMann\Sessionz\Manager')) {
-    exit('WP Session Manager requires Composer autoloading, which is not configured');
+/**
+ * Initialize the plugin, bootstrap autoloading, and register default hooks
+ */
+function wp_session_manager_initialize()
+{
+    $wp_session_autoload = __DIR__ . '/vendor/autoload.php';
+    if (file_exists($wp_session_autoload)) {
+        require_once $wp_session_autoload;
+    }
+
+    if (!class_exists('EAMann\Sessionz\Manager')) {
+        exit('WP Session Manager requires Composer autoloading, which is not configured');
+    }
+
+    // Queue up the session stack.
+    $wp_session_handler = EAMann\Sessionz\Manager::initialize();
+
+    // Fall back to database storage where needed.
+    if (defined('WP_SESSION_USE_OPTIONS') && WP_SESSION_USE_OPTIONS) {
+        $wp_session_handler->addHandler(new \EAMann\WPSession\OptionsHandler());
+    } else {
+        $wp_session_handler->addHandler(new \EAMann\WPSession\DatabaseHandler());
+    }
+
+    // If we have an external object cache, let's use it!
+    if (wp_using_ext_object_cache()) {
+        $wp_session_handler->addHandler(new EAMann\WPSession\CacheHandler());
+    }
+
+    // Decrypt the data surfacing from external storage.
+    if (defined('WP_SESSION_ENC_KEY') && WP_SESSION_ENC_KEY) {
+        $wp_session_handler->addHandler(new \EAMann\Sessionz\Handlers\EncryptionHandler(WP_SESSION_ENC_KEY));
+    }
+
+    // Use an in-memory cache for the instance if we can. This will only help in rare cases.
+    $wp_session_handler->addHandler(new \EAMann\Sessionz\Handlers\MemoryHandler());
+
+    // Create the required table.
+    add_action('admin_init', ['EAMann\WPSession\DatabaseHandler', 'createTable']);
+    add_action('wp_session_init', ['EAMann\WPSession\DatabaseHandler', 'createTable']);
+    add_action('wp_install', ['EAMann\WPSession\DatabaseHandler', 'createTable']);
+    register_activation_hook(__FILE__, ['EAMann\WPSession\DatabaseHandler', 'createTable']);
 }
 
-// Queue up the session stack.
-$wp_session_handler = EAMann\Sessionz\Manager::initialize();
-
-// Fall back to database storage where needed.
-if (defined('WP_SESSION_USE_OPTIONS') && WP_SESSION_USE_OPTIONS) {
-    $wp_session_handler->addHandler(new \EAMann\WPSession\OptionsHandler());
-} else {
-    $wp_session_handler->addHandler(new \EAMann\WPSession\DatabaseHandler());
+/**
+ * Print an admin notice if we're on a bad version of PHP.
+ */
+function wp_session_manager_deactivated_notice() {
+    $message = sprintf(
+        __(
+            'WP Session Manager requires PHP %s or newer. Your system is running PHP %s. Sessions are disabled. Please contact your system administrator to upgrade!',
+            'wp-session-manager'
+        ),
+        WP_SESSION_MINIMUM_PHP_VERSION,
+        PHP_VERSION
+    );
+    ?>
+    <div class="notice notice-error">
+        <p><?php echo esc_html($message); ?></p>
+    </div>
+    <?php
 }
-
-// If we have an external object cache, let's use it!
-if (wp_using_ext_object_cache()) {
-    $wp_session_handler->addHandler(new EAMann\WPSession\CacheHandler());
-}
-
-// Decrypt the data surfacing from external storage.
-if (defined('WP_SESSION_ENC_KEY') && WP_SESSION_ENC_KEY) {
-    $wp_session_handler->addHandler(new \EAMann\Sessionz\Handlers\EncryptionHandler(WP_SESSION_ENC_KEY));
-}
-
-// Use an in-memory cache for the instance if we can. This will only help in rare cases.
-$wp_session_handler->addHandler(new \EAMann\Sessionz\Handlers\MemoryHandler());
-
-// Create the required table.
-add_action('admin_init', ['EAMann\WPSession\DatabaseHandler', 'createTable']);
-add_action('wp_session_init', ['EAMann\WPSession\DatabaseHandler', 'createTable']);
-add_action('wp_install', ['EAMann\WPSession\DatabaseHandler', 'createTable']);
-register_activation_hook(__FILE__, ['EAMann\WPSession\DatabaseHandler', 'createTable']);
 
 /**
  * If a session hasn't already been started by some external system, start one!
@@ -56,12 +85,19 @@ function wp_session_manager_start_session()
 {
     $bootstrap = \EAMann\WPSession\DatabaseHandler::createTable();
 
-    if (! is_wp_error($bootstrap) && session_status() !== PHP_SESSION_ACTIVE) {
+    if (!is_wp_error($bootstrap) && session_status() !== PHP_SESSION_ACTIVE) {
         session_start();
     }
 }
 
-// Start up session management, if we're not in the CLI.
-if (!defined('WP_CLI') || false === WP_CLI) {
-    add_action('plugins_loaded', 'wp_session_manager_start_session', 10, 0);
+// WordPress won't enforce the minimum version of PHP for us, so we need to check.
+if (version_compare(PHP_VERSION, WP_SESSION_MINIMUM_PHP_VERSION, '<')) {
+    add_action('admin_notices', 'wp_session_manager_deactivated_notice');
+} else {
+    wp_session_manager_initialize();
+
+    // Start up session management, if we're not in the CLI.
+    if (!defined('WP_CLI') || false === WP_CLI) {
+        add_action('plugins_loaded', 'wp_session_manager_start_session', 10, 0);
+    }
 }

--- a/wp-session-manager.php
+++ b/wp-session-manager.php
@@ -11,7 +11,7 @@
  * @package WP Session Manager
  */
 
-if(!defined('WP_SESSION_MINIMUM_PHP_VERSION')) {
+if (!defined('WP_SESSION_MINIMUM_PHP_VERSION')) {
     define('WP_SESSION_MINIMUM_PHP_VERSION', '7.1.0');
 }
 
@@ -62,10 +62,11 @@ function wp_session_manager_initialize()
 /**
  * Print an admin notice if we're on a bad version of PHP.
  */
-function wp_session_manager_deactivated_notice() {
+function wp_session_manager_deactivated_notice()
+{
     $message = sprintf(
         __(
-            'WP Session Manager requires PHP %s or newer. Your system is running PHP %s. Sessions are disabled. Please contact your system administrator to upgrade!',
+            'WP Session Manager requires PHP %s or newer. Please contact your system administrator to upgrade!',
             'wp-session-manager'
         ),
         WP_SESSION_MINIMUM_PHP_VERSION,


### PR DESCRIPTION
Bugfixes in v4.1.0:
- Fix: Add some defense to ensure end users are running the correct version of PHP before loading the system. (#76)
- Fix: Eliminate a race condition where another plugin or the theme created the session first. (#75)
- Fix: Schedule a cron to auto-delete expired sessions. (#77)