### PR TITLE
# Added 'function_exists' condition to suppress occasional re-declara…

### DIFF
--- a/wp-session-manager.php
+++ b/wp-session-manager.php
@@ -133,10 +133,12 @@ function wp_session_manager_deactivated_notice()
 /**
  * If a session hasn't already been started by some external system, start one!
  */
-function wp_session_manager_start_session()
-{
-    if (session_status() !== PHP_SESSION_ACTIVE) {
-        session_start();
+if ( ! function_exists( 'wp_session_manager_start_session' )) {
+    function wp_session_manager_start_session()
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
     }
 }
 


### PR DESCRIPTION
In few very rare cases we get re-declaration fatal error when two different plug-ins uses this same package. For this issue I have added 'function_exists' condition to suppress occasional re-declaration fatal error.

Please, review and accept this pull request. 